### PR TITLE
cmsis: Fix CMSIS_6 git submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "CMSIS_6"]
 	path = CMSIS_6
 	url = https://github.com/ARM-software/CMSIS_6.git
-  branch = develop
+  branch = main
 [submodule "CMSIS-DSP"]
 	path = CMSIS-DSP
 	url = https://github.com/arm-software/CMSIS-DSP.git

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ $_IAR_CMSIS_DSP_$/Lib/iar_<library-selection>_math.a
 
 ## Updating the CMSIS submodules
 For getting the newest versions of the CMSIS submodules in your repository, use:
-```
-git submodule foreach git pull
+```bash
+git submodule update --recursive --remote
 ```
 
 ## Support/Contact


### PR DESCRIPTION
The CMSIS_6 submodule origin has changed its structure. 
The git workflow changed and therefore the `develop` branch was replaced by `main`.

Also updated the documentation for explicit submodule updates from the used remotes.

Closes #4.